### PR TITLE
fix(nix): Update macos.nix daemon setting and Makefile execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,8 @@ nix/setup:
 	@git commit -m "Initial commit for Nix configuration" || true
 	@echo "=> Running initial nix build for host: $(NIX_HOST_NAME)..."
 	@if [ "$$(uname -s)" = "Darwin" ]; then \
+		echo "=> Note: Running nix-darwin switch as a regular user to avoid Home Manager conflicts."; \
+		echo "=> (sudo permissions will be automatically requested during the build process if needed)"; \
 		. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix run nix-darwin -- switch --flake .#$(NIX_HOST_NAME); \
 	elif grep -q "NixOS" /etc/os-release >/dev/null 2>&1 || [ -f /etc/NIXOS ]; then \
 		echo "=> NixOS detected. Updating channels and flakes..."; \

--- a/nix/modules/macos.nix
+++ b/nix/modules/macos.nix
@@ -237,7 +237,7 @@
   };
 
   # Auto upgrade nix package and the daemon service.
-  services.nix-daemon.enable = true;
+  nix.enable = true;
 
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog


### PR DESCRIPTION
This PR makes two important updates for `nix-darwin` environments on macOS:

1. **Update `macos.nix`**: Replaced the deprecated `services.nix-daemon.enable = true;` with `nix.enable = true;` to conform with the latest `nix-darwin` and NixOS modules specifications.
2. **Update `Makefile`**: Modified the execution of `nix run nix-darwin` to include clarifying comments stating that this command must be run as a standard user. Running as a standard user avoids conflicts with Home Manager, and the execution implicitly requests `sudo` access only when needed by the internal build process.

---
*PR created automatically by Jules for task [1223850200596941570](https://jules.google.com/task/1223850200596941570) started by @kpango*