### PR TITLE
fix(setup): make nix/setup issues on macos and linux

### DIFF
--- a/Makefile.d/nix.mk
+++ b/Makefile.d/nix.mk
@@ -14,8 +14,8 @@ define NIX_SETUP_DARWIN
 	if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then \
 		. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; \
 	fi; \
-	sudo $$(which nix) run github:joshryandavis/defaults2nix -- -all -filter dates,state,uuids -o ./all-defaults.nix; \
-	sudo chown $$(whoami) ./all-defaults.nix || true; \
+	$$(which nix) run github:joshryandavis/defaults2nix -- -all -filter dates,state,uuids -out ./all-defaults.nix; \
+	if [ -n "$$SUDO_USER" ]; then sudo chown $$SUDO_USER ./all-defaults.nix || true; fi; \
 	if [ ! -s ./all-defaults.nix ]; then \
 		echo "Warning: defaults2nix failed or returned empty. Creating an empty fallback."; \
 		echo "{}" > ./all-defaults.nix; \
@@ -25,13 +25,13 @@ endef
 define NIX_BUILD_NIXOS
 	echo "=> NixOS detected. Updating channels and flakes..."; \
 	sudo nix-channel --update; \
-	nix flake update; \
+	nix flake update ./nix; \
 	if [ -f /mnt/etc/nixos/configuration.nix ]; then \
 		echo "=> Installing NixOS to /mnt..."; \
-		sudo nixos-install --root /mnt --flake .#$(NIX_HOST_NAME); \
+		sudo nixos-install --root /mnt --flake ./nix#$(NIX_HOST_NAME); \
 	else \
 		echo "=> Rebuilding NixOS..."; \
-		sudo nixos-rebuild switch --flake .#$(NIX_HOST_NAME); \
+		sudo nixos-rebuild switch --flake ./nix#$(NIX_HOST_NAME); \
 	fi
 endef
 
@@ -42,7 +42,7 @@ nix/setup:
 	@echo "=========================================================="
 	@if ! command -v nix >/dev/null 2>&1; then \
 		echo "=> Installing Nix (Determinate Systems)..."; \
-		curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install; \
+		curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm; \
 	else \
 		echo "=> Nix is already installed."; \
 	fi
@@ -51,22 +51,39 @@ nix/setup:
 	fi
 	@echo "=> Initializing Git repository (Flakes require files to be tracked by Git)..."
 	@if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
-		git init; \
+		if [ -n "$$SUDO_USER" ]; then sudo -u $$SUDO_USER git init; else git init; fi; \
 	fi
 	@echo "=> Injecting absolute dotfiles path from git..."
 	@sed -i -e '/dotfilesDir = {/,/};/s|linux = ".*";|linux = "$(ROOTDIR)";|g' nix/core/settings.nix
 	@sed -i -e '/dotfilesDir = {/,/};/s|darwin = ".*";|darwin = "$(ROOTDIR)";|g' nix/core/settings.nix
-	@git add .
-	@git commit -m "Initial commit for Nix configuration" || true
+	@if [ -n "$$SUDO_USER" ]; then \
+		sudo -u $$SUDO_USER git add .; \
+		if ! sudo -u $$SUDO_USER git config user.name >/dev/null 2>&1; then sudo -u $$SUDO_USER git config user.name "$$SUDO_USER"; fi; \
+		if ! sudo -u $$SUDO_USER git config user.email >/dev/null 2>&1; then sudo -u $$SUDO_USER git config user.email "$$SUDO_USER@localhost"; fi; \
+		sudo -u $$SUDO_USER git commit -m "Initial commit for Nix configuration" || true; \
+	else \
+		git add .; \
+		if ! git config user.name >/dev/null 2>&1; then git config user.name "$$(whoami)"; fi; \
+		if ! git config user.email >/dev/null 2>&1; then git config user.email "$$(whoami)@localhost"; fi; \
+		git commit -m "Initial commit for Nix configuration" || true; \
+	fi
 	@echo "=> Running initial nix build for host: $(NIX_HOST_NAME)..."
 	@if [ "$$(uname -s)" = "Darwin" ]; then \
 		echo "=> Note: Running nix-darwin switch as a regular user to avoid Home Manager conflicts."; \
 		echo "=> (sudo permissions will be automatically requested during the build process if needed)"; \
-		. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix run nix-darwin -- switch --flake .#$(NIX_HOST_NAME); \
+		if [ -n "$$SUDO_USER" ]; then \
+			if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; fi; sudo -u $$SUDO_USER sh -c "cd '$$PWD' && nix run nix-darwin -- switch --flake ./nix#$(NIX_HOST_NAME)"; \
+		else \
+			if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; fi; nix run nix-darwin -- switch --flake ./nix#$(NIX_HOST_NAME); \
+		fi; \
 	elif grep -q "NixOS" /etc/os-release >/dev/null 2>&1 || [ -f /etc/NIXOS ]; then \
 		$(NIX_BUILD_NIXOS); \
 	else \
-		. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && sudo nixos-rebuild switch --flake .#$(NIX_HOST_NAME); \
+		if command -v nixos-rebuild >/dev/null 2>&1; then \
+			if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; fi; sudo nixos-rebuild switch --flake ./nix#$(NIX_HOST_NAME); \
+		else \
+			echo "=> nixos-rebuild not found, assuming non-NixOS Linux. Skipping NixOS rebuild."; \
+		fi; \
 	fi
 	@echo "=========================================================="
 	@echo " Setup complete! Please open a new terminal or run 'exec zsh'"


### PR DESCRIPTION
Fixes `make nix/setup` issues:
- `defaults2nix` tool usage fixed (`-o` -> `-out`).
- `nix-darwin` missing flake path fixed (`flake .#` -> `./nix#`).
- Git identity missing configuration fixed when executed from `sudo`.
- Graceful skip for non-nixos linux environments looking for `nixos-rebuild`.

---
*PR created automatically by Jules for task [7564313996400980523](https://jules.google.com/task/7564313996400980523) started by @kpango*