### PR TITLE
fix(macOS): Use sudo for nix-darwin system activation

### DIFF
--- a/Makefile.d/nix.mk
+++ b/Makefile.d/nix.mk
@@ -69,12 +69,12 @@ nix/setup:
 	fi
 	@echo "=> Running initial nix build for host: $(NIX_HOST_NAME)..."
 	@if [ "$$(uname -s)" = "Darwin" ]; then \
-		echo "=> Note: Running nix-darwin switch as a regular user to avoid Home Manager conflicts."; \
-		echo "=> (sudo permissions will be automatically requested during the build process if needed)"; \
+		echo "=> Note: Running nix-darwin switch as root."; \
+		echo "=> (nix-darwin now requires root for system activation)"; \
 		if [ -n "$$SUDO_USER" ]; then \
-			if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; fi; sudo -u $$SUDO_USER sh -c "cd '$$PWD' && nix run nix-darwin -- switch --flake ./nix#$(NIX_HOST_NAME)"; \
+			if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; fi; sudo -u $$SUDO_USER sh -c "cd '$$PWD' && sudo nix run nix-darwin -- switch --flake ./nix#$(NIX_HOST_NAME)"; \
 		else \
-			if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; fi; nix run nix-darwin -- switch --flake ./nix#$(NIX_HOST_NAME); \
+			if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; fi; sudo nix run nix-darwin -- switch --flake ./nix#$(NIX_HOST_NAME); \
 		fi; \
 	elif grep -q "NixOS" /etc/os-release >/dev/null 2>&1 || [ -f /etc/NIXOS ]; then \
 		$(NIX_BUILD_NIXOS); \


### PR DESCRIPTION
A recent change in `nix-darwin` (commit `516dbe1fa40548945f18135875ed22228db4ce33` on Jan 11, 2025) requires system activation (`darwin-rebuild switch` and `activate`) to run as `root`. Because of this change, `nix run nix-darwin -- switch` now fails with `system activation must now be run as root` unless it's prefixed with `sudo`.

This commit addresses the issue by:
1. Updating `Makefile.d/nix.mk` to prepend `sudo` to the `nix run nix-darwin -- switch --flake` command.
2. Updating the terminal output messages (`echo`) to accurately state that `nix-darwin switch` now requires root.

---
*PR created automatically by Jules for task [11411094842594455114](https://jules.google.com/task/11411094842594455114) started by @kpango*