### PR TITLE
docs(CLAUDE.md): add macOS install notes for rtk/codegraph/hadolint

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -32,11 +32,11 @@ fail-open（該当機能のみスキップ、致命的にはならない）す�
 
 | Tool            | 用途                                             | 入手方法                                                                                              |
 | --------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| `rtk`           | Bash コマンドのトークン最適化(詳細は [[RTK.md]]) | `paru -S rtk-ai-bin`                                                                                  |
-| `codegraph`     | コードナビゲーション MCP server                  | npm グローバルパッケージ `@colbymchenry/codegraph`                                                    |
+| `rtk`           | Bash コマンドのトークン最適化(詳細は [[RTK.md]]) | `paru -S rtk-ai-bin`(Arch専用。macOS向け配布物は無し — 未導入のままfail-openを許容する)               |
+| `codegraph`     | コードナビゲーション MCP server                  | npm グローバルパッケージ `@colbymchenry/codegraph`(macOS+nix環境ではnpmのglobal prefixがnix store配下の読み取り専用パスを指し実質使用不可 — 代わりに `bun install -g @colbymchenry/codegraph` を使う。`~/.bun/bin` は `_base_path` で既にPATH済み) |
 | `graphify`      | ナレッジグラフ CLI                               | zsh 関数ラッパー経由（`pass show ai/gemini` から API キー取得、`pass` に `ai/gemini` エントリが必要） |
 | `golangci-lint` | Go lint(`swarm-post-edit-lint.sh` 等)            | 公式インストールスクリプト                                                                            |
-| `hadolint`      | Dockerfile lint                                  | `paru -S hadolint-bin`                                                                                |
+| `hadolint`      | Dockerfile lint                                  | `paru -S hadolint-bin`(macOS: `nix profile install nixpkgs#hadolint`)                                 |
 | `buf`           | protobuf lint/breaking change 検出               | `go install github.com/bufbuild/buf/cmd/buf@latest`                                                   |
 | `dlv`           | Go デバッガ                                      | `go install github.com/go-delve/delve/cmd/dlv@latest`                                                 |
 | `jq`            | JSON 処理(多数の hook が使用)                    | `pacman -S jq`                                                                                        |


### PR DESCRIPTION
## 背景

`/swarm-meta` 経由で「macOS環境で `$HOME/.local/bin` にPATHが通っていない」という報告を調査。

- 新規シェル(env -i + zsh -lic/-ic/-c)で実測した結果、`.local/bin` は既にPATHに含まれていた(同日の別ミッションで修正済み)。おそらく修正前に作成された古いtmuxペインでの観測と推定。
- 一方で、CLAUDE.md記載の必須外部ツールを新規シェルで確認したところ `rtk` / `codegraph` / `hadolint` が未解決。掘り下げた結果:
  - `codegraph`: npm の global prefix がこのmacOS+nix環境ではnix store配下の読み取り専用パスを指し実質使用不可(かつそのbinもPATH外)。`bun install -g @colbymchenry/codegraph` に切替え、動作確認済み(`~/.bun/bin` は既にPATH済み)。
  - `rtk` / `hadolint`: CLAUDE.mdの入手方法がArch専用(`paru -S`)でmacOS代替が未記載だった。

## 変更内容

`claude/CLAUDE.md` の Required External Tools 表に3行分の追記のみ(コード変更なし)。

- `rtk`: macOS向け配布物が無い旨を明記(fail-open前提を許容)
- `codegraph`: macOS+nix環境でのnpm prefix問題と `bun install -g` への切替え手順を追記
- `hadolint`: macOS向け `nix profile install nixpkgs#hadolint` を追記

## 検証

- 新規シェル(env -i zsh -lic/-ic/-c、Claude Codeプロセスの環境を継承しない状態)で `.local/bin` PATH解決を確認
- `bun install -g @colbymchenry/codegraph` 実施後、新規シェルで `codegraph --version` (1.5.0) を確認
- markdownテーブルとして崩れていないことを目視確認(コード/JSON/Dockerfile以外のためlint対象外)

Generated with [Claude Code](https://claude.ai/claude-code)